### PR TITLE
Fix exception type in user update and correct comment typos

### DIFF
--- a/TaskManagerApp/src/main/java/com/taskmanager/app/comment/CommentService.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/comment/CommentService.java
@@ -46,7 +46,7 @@ public class CommentService {
     // READ BY UID
     public CommentResponse getCommentByUid(UUID commentUid) {
         Comment comment = commentRepository.findByCommentUid(commentUid)
-                .orElseThrow(()-> new CommentNotFoundException("Cooment not found with UID "+commentUid));
+                .orElseThrow(()-> new CommentNotFoundException("Comment not found with UID "+commentUid));
         return convertEntityToResponse(comment);
     }
 
@@ -74,7 +74,7 @@ public class CommentService {
     // UPDATE
     public CommentResponse updateComment(UUID commentUid, CommentResponse commentResponse) {
         Comment existingComment = commentRepository.findByCommentUid(commentUid)
-                .orElseThrow(()-> new CommentNotFoundException("Cooment not found with UID "+commentUid));
+                .orElseThrow(()-> new CommentNotFoundException("Comment not found with UID "+commentUid));
 
         TodoItem todoItem = todoItemRepository.findByTodoUid(commentResponse.getTodoItem().getTodoUid())
                 .orElseThrow(() -> new TodoItemNotFoundException("TodoItem not found with Uid: " + commentResponse.getTodoItem().getTodoUid()));
@@ -93,7 +93,7 @@ public class CommentService {
     // DELETE
     public void deleteComment(UUID commentUid) {
         Comment comment = commentRepository.findByCommentUid(commentUid)
-                .orElseThrow(()-> new CommentNotFoundException("Cooment not found with UID "+commentUid));
+                .orElseThrow(()-> new CommentNotFoundException("Comment not found with UID "+commentUid));
         commentRepository.delete(comment);
     }
 

--- a/TaskManagerApp/src/main/java/com/taskmanager/app/user/TaskUserService.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/user/TaskUserService.java
@@ -56,10 +56,10 @@ public class TaskUserService {
 	public UserCreationResponse update(Long userId, UserCreationResponse userCreationResponse) {
 		System.out.println("🔍 Checking user existence for ID: " + userId);
 
-		TaskUser taskUser = taskUserRepository.findById(userId).orElseThrow(() -> {
-			System.out.println("❌ User NOT FOUND with ID: " + userId);
-			return new TodoItemNotFoundException("User not found with id " + userId);
-		});
+                TaskUser taskUser = taskUserRepository.findById(userId).orElseThrow(() -> {
+                        System.out.println("❌ User NOT FOUND with ID: " + userId);
+                        return new TaskUserNotFoundException("User not found with id " + userId);
+                });
 
 		System.out.println("✅ User found: " + taskUser.getUsername());
 


### PR DESCRIPTION
## Summary
- fix wrong exception thrown when updating a user
- correct typos in CommentService error messages

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68624d7f6e648325977ac4f7a70fd54c