### PR TITLE
Fix integration test profile mismatch

### DIFF
--- a/TaskManagerApp/src/test/java/com/taskmanager/app/BaseIT.java
+++ b/TaskManagerApp/src/test/java/com/taskmanager/app/BaseIT.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         classes = TaskManagerAppApplication.class,
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
 )
-@ActiveProfiles("it")
+@ActiveProfiles("test")
 public abstract class BaseIT {
 
     @Container


### PR DESCRIPTION
## Summary
- switch BaseIT integration tests to use the `test` profile

## Testing
- `./mvnw test -q` *(fails: unable to download Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6862507f582c8325a05db7341612e1c5