### PR TITLE
Clean up JPA configuration

### DIFF
--- a/TaskManagerApp/src/main/java/com/taskmanager/app/TaskManagerAppApplication.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/TaskManagerAppApplication.java
@@ -2,14 +2,8 @@ package com.taskmanager.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableJpaRepositories(basePackages = "com.taskmanager.app.repository")
-@EntityScan(basePackages = "com.taskmanager.app.entity")
 public class TaskManagerAppApplication {
     public static void main(String[] args) {
         SpringApplication.run(TaskManagerAppApplication.class, args);


### PR DESCRIPTION
## Summary
- remove `@EntityScan` and `@EnableJpaRepositories` from `TaskManagerAppApplication`
- keep scanning annotations centralized in `DomainConfig`

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68650f63a9c08325935528326f90bdea