### PR TITLE
Add global handlers for domain exceptions

### DIFF
--- a/TaskManagerApp/src/main/java/com/taskmanager/app/exceptions/GlobalExceptionHandler.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/exceptions/GlobalExceptionHandler.java
@@ -8,6 +8,9 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import com.taskmanager.app.todo.TodoItemNotFoundException;
+import com.taskmanager.app.project.ProjectNotFoundException;
+import com.taskmanager.app.user.TaskUserNotFoundException;
+import com.taskmanager.app.comment.CommentNotFoundException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
@@ -16,9 +19,33 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleTodoItemNotFoundException(TodoItemNotFoundException ex) {
         // Create an ErrorResponse object with the message from the exception
         ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
-        
+
         // Return the error response wrapped in ResponseEntity with NOT_FOUND status
         return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(ProjectNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleProjectNotFoundException(ProjectNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(TaskUserNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleTaskUserNotFoundException(TaskUserNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleCommentNotFoundException(CommentNotFoundException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(ex.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 }
 


### PR DESCRIPTION
## Summary
- add missing imports in `GlobalExceptionHandler`
- handle project, user and comment not found
- handle bad requests via `IllegalArgumentException`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_686521fd295c83259c638bcd787bfe89