### PR TITLE
Enable scheduled due date notifications

### DIFF
--- a/TaskManagerApp/pom.xml
+++ b/TaskManagerApp/pom.xml
@@ -30,7 +30,7 @@
 		<java.version>21</java.version>
 		<testcontainers.version>1.19.8</testcontainers.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
@@ -39,10 +39,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jdbc</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-jpa</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-kafka</artifactId>
+                </dependency>
 				<dependency>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-mail</artifactId>

--- a/TaskManagerApp/src/main/java/com/taskmanager/app/TaskManagerAppApplication.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/TaskManagerAppApplication.java
@@ -2,8 +2,10 @@ package com.taskmanager.app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class TaskManagerAppApplication {
     public static void main(String[] args) {
         SpringApplication.run(TaskManagerAppApplication.class, args);

--- a/TaskManagerApp/src/main/java/com/taskmanager/app/notifications/DueDateNotifier.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/notifications/DueDateNotifier.java
@@ -1,29 +1,39 @@
-/*
- * package com.taskmanager.app.notifications;
- * 
- * import com.taskmanager.app.todo.TodoItemRepository; import
- * com.taskmanager.app.user.TaskUserRepository; import
- * com.taskmanager.app.todo.TodoItem;
- * 
- * import org.springframework.scheduling.annotation.Scheduled; import
- * org.springframework.stereotype.Component;
- * 
- * import java.time.LocalDateTime; import java.util.List;
- * 
- * @Component public class DueDateNotifier {
- * 
- * private final TodoItemRepository todoItemRepository; private final
- * NotificationService notificationService;
- * 
- * public DueDateNotifier(TodoItemRepository todoItemRepository,
- * NotificationService notificationService) { this.todoItemRepository =
- * todoItemRepository; this.notificationService = notificationService; }
- * 
- * @Scheduled(cron = "0 0 * * * *") // Every hour public void notifyDueTasks() {
- * LocalDateTime now = LocalDateTime.now(); LocalDateTime threshold =
- * now.plusHours(6); // Notify 6 hours before due
- * 
- * List<TodoItem> dueSoon = todoItemRepository.findByDueDateBetween(now,
- * threshold); dueSoon.forEach(task ->
- * notificationService.sendDueSoonNotification(task)); } }
+package com.taskmanager.app.notifications;
+
+import com.taskmanager.app.todo.TodoItem;
+import com.taskmanager.app.todo.TodoItemRepository;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Scheduled component that notifies users about tasks that are due soon.
  */
+@Component
+public class DueDateNotifier {
+
+    private final TodoItemRepository todoItemRepository;
+    private final NotificationService notificationService;
+
+    public DueDateNotifier(
+            TodoItemRepository todoItemRepository,
+            NotificationService notificationService) {
+        this.todoItemRepository = todoItemRepository;
+        this.notificationService = notificationService;
+    }
+
+    /**
+     * Runs every hour and notifies about tasks due within the next six hours.
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    public void notifyDueTasks() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime threshold = now.plusHours(6);
+
+        List<TodoItem> dueSoon = todoItemRepository.findByDueByBetween(now, threshold);
+        dueSoon.forEach(notificationService::sendDueSoonNotification);
+    }
+}

--- a/TaskManagerApp/src/main/java/com/taskmanager/app/notifications/NotificationService.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/notifications/NotificationService.java
@@ -1,8 +1,16 @@
-/*
- * package com.taskmanager.app.notifications;
- * 
- * import com.taskmanager.app.todo.TodoItem;
- * 
- * public interface NotificationService { void sendDueSoonNotification(TodoItem
- * todoItem); }
+package com.taskmanager.app.notifications;
+
+import com.taskmanager.app.todo.TodoItem;
+
+/**
+ * Simple contract for sending notifications about {@link TodoItem}s.
  */
+public interface NotificationService {
+
+    /**
+     * Send a notification that the given todo item is due soon.
+     *
+     * @param todoItem the item that will be due shortly
+     */
+    void sendDueSoonNotification(TodoItem todoItem);
+}

--- a/TaskManagerApp/src/main/java/com/taskmanager/app/notifications/NotificationServiceImpl.java
+++ b/TaskManagerApp/src/main/java/com/taskmanager/app/notifications/NotificationServiceImpl.java
@@ -1,18 +1,30 @@
-/*
- * package com.taskmanager.app.notifications;
- * 
- * import org.springframework.stereotype.Service;
- * 
- * import com.taskmanager.app.todo.TodoItem;
- * 
- * @Service public class NotificationServiceImpl implements NotificationService
- * {
- * 
- * @Override public void sendDueSoonNotification(TodoItem todoItem) {
- * System.out.println("Reminder: Task \"" + todoItem.getDescription() +
- * "\" is due soon!");
- * 
- * }
- * 
- * }
+package com.taskmanager.app.notifications;
+
+import com.taskmanager.app.todo.TodoItem;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Default implementation that publishes reminders to a Kafka topic.
  */
+@Service
+public class NotificationServiceImpl implements NotificationService {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final String reminderTopic;
+
+    public NotificationServiceImpl(
+            KafkaTemplate<String, String> kafkaTemplate,
+            @Value("${app.kafka.reminder-topic}") String reminderTopic) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.reminderTopic = reminderTopic;
+    }
+
+    @Override
+    public void sendDueSoonNotification(TodoItem todoItem) {
+        String message = "Reminder: Task \"" + todoItem.getTaskName()
+                + "\" is due soon at " + todoItem.getDueBy();
+        kafkaTemplate.send(reminderTopic, message);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `NotificationService` and default console implementation
- finalize `DueDateNotifier` scheduled component
- enable Spring scheduling in the main application
- send reminders via Kafka instead of logging

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686531a649a883258599b5229013e763